### PR TITLE
add a simple CMakeLists.txt at the top level to build static lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,8 @@
+project(TrianglePP)
+
+file(GLOB TPP_SOURCES "source/*.cpp")
+
+# Create a static library from TrianglePP source files
+add_library(TrianglePP STATIC ${TPP_SOURCES})
+
+target_include_directories(TrianglePP PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/source)


### PR DESCRIPTION
this made it convenient for me to include TrianglePP as a git submodule in an existing project and have it build the static library